### PR TITLE
Update to accommodate Unicode characters

### DIFF
--- a/scripts/coseis_sar.py
+++ b/scripts/coseis_sar.py
@@ -1,4 +1,5 @@
 import re
+import unicodedata
 import os
 import argparse
 import asf_search as asf
@@ -998,14 +999,18 @@ def run_dockerized_topsApp(json_data):
 
 def to_snake_case(input_string):
     """
-    Convert the given string to snake_case. Used to create uniform-case output directory names
-    :param input_string: string to convert to snake_case
-    :return: snake_case version of the input string
+    Convert the given string to snake_case with ASCII-safe characters.
+    Strips accents and transliterates Unicode to closest ASCII.
     """
+    # Normalize and transliterate Unicode characters to closest ASCII equivalent
+    normalized = unicodedata.normalize('NFKD', input_string).encode('ascii', 'ignore').decode('ascii')
+
     # Replace non-alphanumeric characters with spaces
-    cleaned_string = re.sub(r'[^\w\s]', '', input_string)
+    cleaned_string = re.sub(r'[^\w\s]', '', normalized)
+
     # Replace spaces with underscores and convert to lowercase
     snake_case_string = re.sub(r'\s+', '_', cleaned_string.strip()).lower()
+
     return snake_case_string
 
 


### PR DESCRIPTION
This modifies the `to_snake_case` function to properly handle Unicode characters in naming. For example, `"M 6.2 - 24 km SE of Marmara Ereğlisi, Turkey` was formerly being converted to `m_62_24_km_se_of_marmara_ere\u011flisi_turkey-D138`
but now is converted to `m_62_24_km_se_of_marmara_ereglisi_turkey-D138`.