### PR TITLE
Add s1c filter

### DIFF
--- a/scripts/coseis_sar.py
+++ b/scripts/coseis_sar.py
@@ -905,6 +905,16 @@ def make_job_json(title, flight_direction, path_number, reference_scenes, second
     return job_json
 
 
+def filter_S1C(job):
+    """Return True if the job does NOT contain any S1C granules in primary or secondary."""
+    job_params = job.get("job_parameters", {})
+    granules = job_params.get("granules", [])
+    secondary = job_params.get("secondary_granules", [])
+
+    # Reject if any granule in either list starts with S1C_
+    return not any(g.startswith("S1C_") for g in granules + secondary)
+
+
 def create_directories_from_json(eq_jsons, root_dir):
     """
     Create directories for each group of SLCs based on the JSON data provided. These directories will be used to store the outputs of the dockerized topsApp.
@@ -1280,9 +1290,10 @@ def main_historic(start_date, end_date = None, aoi = None, pairing_mode = None, 
                 if job_list:    # produce the list of jobs needed for HYPE3 processing, but do not run any jobs
                     for i, eq_json in enumerate(eq_jsons):
                         for j, json_data in enumerate(eq_json): 
-                            jobs_dict.append(json_data)
+                            if filter_S1C(json_data):  # apply filter to remove jobs contain Sentinel-1C granules
+                                jobs_dict.append(json_data)
 
-                else:         # run dockerizedTopsApp locally
+                else:           # run dockerizedTopsApp locally
                     
                     # Create directories for each group of SLCs based on the JSON data provided
                     dirnames, total = create_directories_from_json(eq_jsons, root_dir)


### PR DESCRIPTION
This PR adds a step to filter out any jobs containing Sentinel-1C granules. This is (currently) necessary as dockerizedTopsApp does not support Sentinel-1C processing. 