### PR TITLE
Use exact SLC acquisition times to resolve same-day coseismic pairing bug

### DIFF
--- a/scripts/coseis.py
+++ b/scripts/coseis.py
@@ -1494,13 +1494,27 @@ def find_reference_and_secondary_pairs(SLCs, time, flight_direction, path_number
         if max_track_area > 0 and (intersection_area / max_track_area) > 0.95:
             initial_pairs.append((date, frames))
     
-    # Split the pairs into pre-seismic, co-seismic, and post-seismic
-    pre_seismic = [pair for pair in initial_pairs if pair[0] < rupture_date_dt]
-    post_seismic = [pair for pair in initial_pairs if pair[0] > rupture_date_dt]
+    pre_seismic = []
+    post_seismic = []
+    
+    for pair in initial_pairs:
+        # pair[1] is the list of frames. Take the exact datetime of the first frame.
+        exact_time = datetime.strptime(pair[1][0]['date'], "%Y-%m-%dT%H:%M:%SZ")
+        
+        if exact_time < rupture_date_dt:
+            pre_seismic.append(pair)
+        elif exact_time > rupture_date_dt:
+            post_seismic.append(pair)
+            
     co_seismic = []
     
     for i in range(len(initial_pairs) - 1):
-        if initial_pairs[i][0] < rupture_date_dt < initial_pairs[i + 1][0]:
+        # Extract the exact datetime for the first slice in each track pass
+        exact_time_1 = datetime.strptime(initial_pairs[i][1][0]['date'], "%Y-%m-%dT%H:%M:%SZ")
+        exact_time_2 = datetime.strptime(initial_pairs[i + 1][1][0]['date'], "%Y-%m-%dT%H:%M:%SZ")
+        
+        # Safely evaluate using precise hour/minute/second boundaries
+        if exact_time_1 < rupture_date_dt < exact_time_2:
             co_seismic = [(initial_pairs[i], initial_pairs[i + 1])]
             break
     


### PR DESCRIPTION
This PR resolves a critical temporal logic bug in `coseis.py` that inadvertently classified same-day, post-earthquake Sentinel-1 acquisitions as pre-earthquake reference images. Previously, when evaluating and grouping SLC pairs in `find_reference_and_secondary_pairs`, the script sliced the acquisition date string (`slc['date'][:10]`), completely truncating the hours, minutes, and seconds to 00:00:00.

Because of this truncation, if a satellite flyover occurred on the exact same calendar day as an earthquake, but several hours after the rupture, the script evaluated the midnight timestamp and incorrectly classified the image as occurring before the earthquake. This resulted in "coseismic" pairs that were actually composed of two post-earthquake images, yielding interferograms with no actual coseismic deformation.

### The Fix
- Refactored the pre_seismic, post_seismic, and co_seismic evaluation blocks to parse the exact, full datetime string (`%Y-%m-%dT%H:%M:%SZ`) directly from the granule metadata.
- Comparisons are now made against the precise, un-truncated USGS earthquake rupture time (`rupture_date_dt`).

This guarantees mathematically rigorous chronological bracketing for all InSAR pairs. The script will now correctly bump same-day, post-earthquake images to the secondary_granules position and look backward to find a true pre-earthquake reference image.